### PR TITLE
Squeeze morph: Adding UCs tests

### DIFF
--- a/news/morphsqueeze.rst
+++ b/news/morphsqueeze.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Polynomial squeeze of x-axis of morphed data
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/src/diffpy/morph/morphs/morphsqueeze.py
+++ b/src/diffpy/morph/morphs/morphsqueeze.py
@@ -16,6 +16,10 @@ class MorphSqueeze(Morph):
     xoutlabel = LABEL_RA
     youtlabel = LABEL_GR
     parnames = ["squeeze"]
+    # extrap_index_low: last index before interpolation region
+    # extrap_index_high: first index after interpolation region
+    extrap_index_low = None
+    extrap_index_high = None
 
     def morph(self, x_morph, y_morph, x_target, y_target):
         """Squeeze the morph function.
@@ -32,13 +36,10 @@ class MorphSqueeze(Morph):
 
         Returns
         -------
-            A tuple (x_morph_out, y_morph_out, x_target_out, y_target_out,
-            min_index, max_index) where the target values remain the same and
-            the morph data is shifted according to the squeeze. The morphed
-            data is returned on the same grid as the unmorphed data.
-            The min_index and max_index are the last index before the
-            interpolated region and the first index after the interpolated
-            region, respectively. If there is no extrapolation it returns None.
+            A tuple (x_morph_out, y_morph_out, x_target_out, y_target_out)
+            where the target values remain the same and the morph data is
+            shifted according to the squeeze. The morphed data is returned on
+            the same grid as the unmorphed data.
 
         Example
         -------
@@ -66,8 +67,8 @@ class MorphSqueeze(Morph):
         self.y_morph_out = CubicSpline(x_squeezed, self.y_morph_in)(
             self.x_morph_in
         )
-        left_extrap = np.where(self.x_morph_in < x_squeezed[0])[0]
-        right_extrap = np.where(self.x_morph_in > x_squeezed[-1])[0]
-        min_index = left_extrap[-1] if left_extrap.size else None
-        max_index = right_extrap[0] if right_extrap.size else None
-        return self.xyallout + (min_index, max_index)
+        low_extrap = np.where(self.x_morph_in < x_squeezed[0])[0]
+        high_extrap = np.where(self.x_morph_in > x_squeezed[-1])[0]
+        self.extrap_index_low = low_extrap[-1] if low_extrap.size else None
+        self.extrap_index_high = high_extrap[0] if high_extrap.size else None
+        return self.xyallout

--- a/src/diffpy/morph/morphs/morphsqueeze.py
+++ b/src/diffpy/morph/morphs/morphsqueeze.py
@@ -4,12 +4,8 @@ from diffpy.morph.morphs.morph import LABEL_GR, LABEL_RA, Morph
 class MorphSqueeze(Morph):
     """Squeeze the morph function.
 
-    This applies a polynomial to squeeze the morph non-linearly. The resulting
-    squeezed morph is interpolated to the (trimmed) target grid.
-    Only the overlapping region between the squeezed morph and the target
-    grid is used. The target is trimmed (or not) accordingly, and the final
-    outputs (morph and target) are returned on the same grid, defined by this
-    trimmed target range.
+    This applies a polynomial to squeeze the morph non-linearly. The morphed
+    data is returned on the same grid as the unmorphed data.
 
     Configuration Variables
     -----------------------
@@ -28,9 +24,5 @@ class MorphSqueeze(Morph):
 
     def morph(self, x_morph, y_morph, x_target, y_target):
         Morph.morph(self, x_morph, y_morph, x_target, y_target)
-        if self.squeeze is None:
-            self.x_morph_out = self.x_morph_in
-            self.y_morph_out = self.y_morph_in
-            return self.xyallout
 
         return self.xyallout

--- a/src/diffpy/morph/morphs/morphsqueeze.py
+++ b/src/diffpy/morph/morphs/morphsqueeze.py
@@ -2,37 +2,8 @@ from diffpy.morph.morphs.morph import LABEL_GR, LABEL_RA, Morph
 
 
 class MorphSqueeze(Morph):
-    """Squeeze the morph function.
-
-    This applies a polynomial to squeeze the morph non-linearly. The morphed
-    data is returned on the same grid as the unmorphed data.
-
-    Configuration Variables
-    -----------------------
-    squeeze : list
-        The polynomial coefficients [a0, a1, ..., an] for the squeeze function
-        where the polynomial would be of the form a0 + a1*x + a2*x^2 and so
-        on.  The order of the polynomial is determined by the length of the
-        list.
-
-    Example
-    -------
-    >>> import numpy as np
-    >>> from numpy.polynomial import Polynomial
-    >>> from diffpy.morph.morphs.morphsqueeze import MorphSqueeze
-
-    >>> x_target = np.linspace(0, 10, 101)
-    >>> y_target = np.sin(x_target)
-    >>> x_morph = np.linspace(0, 10, 101)
-    >>> squeeze_coeff = [0.1, -0.01, 0.005]
-    >>> poly = Polynomial(squeeze_coeff)
-    >>> y_morph = np.sin(x_morph + poly(x_morph))
-
-    >>> morph = MorphSqueeze()
-    >>> morph.squeeze = squeeze_coeff
-    >>> x_morph_out, y_morph_out, x_target_out, y_target_out = morph(
-    ...     x_morph, y_morph, x_target, y_target)
-    """
+    """Apply a polynomial to squeeze the morph function. The morphed
+    data is returned on the same grid as the unmorphed data."""
 
     # Define input output types
     summary = "Squeeze morph by polynomial shift"
@@ -43,7 +14,44 @@ class MorphSqueeze(Morph):
     parnames = ["squeeze"]
 
     def morph(self, x_morph, y_morph, x_target, y_target):
-        """Apply a polynomial to squeeze the morph function"""
+        """Squeeze the morph function.
+
+        This applies a polynomial to squeeze the morph non-linearly.
+
+        Configuration Variables
+        -----------------------
+        squeeze : list
+            The polynomial coefficients [a0, a1, ..., an] for the squeeze
+            function where the polynomial would be of the form
+            a0 + a1*x + a2*x^2 and so on.  The order of the polynomial is
+            determined by the length of the list.
+
+        Returns
+        -------
+            A tuple (x_morph_out, y_morph_out, x_target_out, y_target_out)
+            where the target values remain the same and the morph data
+            is shifted according to the squeeze. The morphed data is
+            returned on the same grid as the unmorphed data.
+
+        Example
+        -------
+        Import the squeeze morph function:
+        >>> from diffpy.morph.morphs.morphsqueeze import MorphSqueeze
+        Provide initial guess for squeezing coefficients:
+        >>> squeeze_coeff = [0.1, -0.01, 0.005]
+        Run the squeeze morph given input morph array (x_morph, y_morph)
+        and target array (x_target, y_target):
+        >>> morph = MorphSqueeze()
+        >>> morph.squeeze = squeeze_coeff
+        >>> x_morph_out, y_morph_out, x_target_out, y_target_out = morph(
+        ...     x_morph, y_morph, x_target, y_target)
+        To access parameters from the morph instance:
+        >>> x_morph_in = morph.x_morph_in
+        >>> y_morph_in = morph.y_morph_in
+        >>> x_target_in = morph.x_target_in
+        >>> y_target_in = morph.y_target_in
+        >>> squeeze_coeff_out = morph.squeeze
+        """
         Morph.morph(self, x_morph, y_morph, x_target, y_target)
 
         return self.xyallout

--- a/src/diffpy/morph/morphs/morphsqueeze.py
+++ b/src/diffpy/morph/morphs/morphsqueeze.py
@@ -1,0 +1,36 @@
+from diffpy.morph.morphs.morph import LABEL_GR, LABEL_RA, Morph
+
+
+class MorphSqueeze(Morph):
+    """Squeeze the morph function.
+
+    This applies a polynomial to squeeze the morph non-linearly. The resulting
+    squeezed morph is interpolated to the (trimmed) target grid.
+    Only the overlapping region between the squeezed morph and the target
+    grid is used. The target is trimmed (or not) accordingly, and the final
+    outputs (morph and target) are returned on the same grid, defined by this
+    trimmed target range.
+
+    Configuration Variables
+    -----------------------
+    squeeze
+        list or array-like
+        Polynomial coefficients [a0, a1, ..., an] for the squeeze function.
+    """
+
+    # Define input output types
+    summary = "Squeeze morph by polynomial shift"
+    xinlabel = LABEL_RA
+    yinlabel = LABEL_GR
+    xoutlabel = LABEL_RA
+    youtlabel = LABEL_GR
+    parnames = ["squeeze"]
+
+    def morph(self, x_morph, y_morph, x_target, y_target):
+        Morph.morph(self, x_morph, y_morph, x_target, y_target)
+        if self.squeeze is None:
+            self.x_morph_out = self.x_morph_in
+            self.y_morph_out = self.y_morph_in
+            return self.xyallout
+
+        return self.xyallout

--- a/src/diffpy/morph/morphs/morphsqueeze.py
+++ b/src/diffpy/morph/morphs/morphsqueeze.py
@@ -21,12 +21,12 @@ class MorphSqueeze(Morph):
     >>> from numpy.polynomial import Polynomial
     >>> from diffpy.morph.morphs.morphsqueeze import MorphSqueeze
 
-    >>> x_morph = np.linspace(0, 10, 101)
     >>> x_target = np.linspace(0, 10, 101)
+    >>> y_target = np.sin(x_target)
+    >>> x_morph = np.linspace(0, 10, 101)
     >>> squeeze_coeff = [0.1, -0.01, 0.005]
     >>> poly = Polynomial(squeeze_coeff)
     >>> y_morph = np.sin(x_morph + poly(x_morph))
-    >>> y_target = np.sin(x_target)
 
     >>> morph = MorphSqueeze()
     >>> morph.squeeze = squeeze_coeff

--- a/src/diffpy/morph/morphs/morphsqueeze.py
+++ b/src/diffpy/morph/morphs/morphsqueeze.py
@@ -9,9 +9,29 @@ class MorphSqueeze(Morph):
 
     Configuration Variables
     -----------------------
-    squeeze
-        list or array-like
-        Polynomial coefficients [a0, a1, ..., an] for the squeeze function.
+    squeeze : list
+        The polynomial coefficients [a0, a1, ..., an] for the squeeze function
+        where the polynomial would be of the form a0 + a1*x + a2*x^2 and so
+        on.  The order of the polynomial is determined by the length of the
+        list.
+
+    Example
+    -------
+    >>> import numpy as np
+    >>> from numpy.polynomial import Polynomial
+    >>> from diffpy.morph.morphs.morphsqueeze import MorphSqueeze
+
+    >>> x_morph = np.linspace(0, 10, 101)
+    >>> x_target = np.linspace(0, 10, 101)
+    >>> squeeze_coeff = [0.1, -0.01, 0.005]
+    >>> poly = Polynomial(squeeze_coeff)
+    >>> y_morph = np.sin(x_morph + poly(x_morph))
+    >>> y_target = np.sin(x_target)
+
+    >>> morph = MorphSqueeze()
+    >>> morph.squeeze = squeeze_coeff
+    >>> x_morph_out, y_morph_out, x_target_out, y_target_out = morph(
+    ...     x_morph, y_morph, x_target, y_target)
     """
 
     # Define input output types
@@ -23,6 +43,7 @@ class MorphSqueeze(Morph):
     parnames = ["squeeze"]
 
     def morph(self, x_morph, y_morph, x_target, y_target):
+        """Apply a polynomial to squeeze the morph function"""
         Morph.morph(self, x_morph, y_morph, x_target, y_target)
 
         return self.xyallout

--- a/tests/test_morphsqueeze.py
+++ b/tests/test_morphsqueeze.py
@@ -29,9 +29,9 @@ morph_target_grids = [
     (np.linspace(0, 10, 101), np.linspace(0, 10, 101)),
     # UC4: Target range wider than morph, same grid density
     (np.linspace(0, 10, 101), np.linspace(-2, 20, 221)),
-    # UC6: Target range wider than morph, finer target grid density
+    # UC6: Target range wider than morph, target grid density finer than morph
     (np.linspace(0, 10, 101), np.linspace(-2, 20, 421)),
-    # UC8: Target range wider than morph, finer morph grid density
+    # UC8: Target range wider than morph, morph grid density finer than target
     (np.linspace(0, 10, 401), np.linspace(-2, 20, 200)),
     # UC10: Morph range starts and ends earlier than target, same grid density
     (np.linspace(-2, 10, 121), np.linspace(0, 20, 201)),

--- a/tests/test_morphsqueeze.py
+++ b/tests/test_morphsqueeze.py
@@ -7,17 +7,17 @@ from diffpy.morph.morphs.morphsqueeze import MorphSqueeze
 squeeze_coeffs_list = [
     # The order of coefficients is [a0, a1, a2, ..., an]
     # Negative cubic squeeze coefficients
-    [-0.2, -0.01, -0.001, -0.0001],
+    [-0.01, -0.0005, -0.0005, -1e-6],
     # Positive cubic squeeze coefficients
     [0.2, 0.01, 0.001, 0.0001],
     # Positive and negative cubic squeeze coefficients
     [0.2, -0.01, 0.002, -0.0001],
     # Quadratic squeeze coefficients
-    [-0.2, 0.005, -0.007],
+    [-0.2, 0.005, -0.0004],
     # Linear squeeze coefficients
     [0.1, 0.3],
     # 4th order squeeze coefficients
-    [0.2, -0.01, 0.001, -0.001, 0.0004],
+    [0.2, -0.01, 0.001, -0.001, 0.0001],
     # Zeros and non-zeros, the full polynomial is applied
     [0, 0.03, 0, -0.0001],
     # Testing zeros, expect no squeezing
@@ -36,7 +36,7 @@ morph_target_grids = [
     # UC10: Morph range starts and ends earlier than target, same grid density
     (np.linspace(-2, 10, 121), np.linspace(0, 20, 201)),
     # UC12: Morph range wider than target, same grid density
-    (np.linspace(-2, 20, 221), np.linspace(0, 10, 101)),
+    (np.linspace(-2, 20, 201), np.linspace(0, 10, 101)),
 ]
 
 

--- a/tests/test_morphsqueeze.py
+++ b/tests/test_morphsqueeze.py
@@ -25,17 +25,17 @@ squeeze_coeffs_list = [
 ]
 morph_target_grids = [
     # UCs from issue 181: https://github.com/diffpy/diffpy.morph/issues/181
-    # UC2: Same grid
+    # UC2: Same range and same grid density
     (np.linspace(0, 10, 101), np.linspace(0, 10, 101)),
-    # UC4: Target extends beyond morph
+    # UC4: Target range wider than morph, same grid density
     (np.linspace(0, 10, 101), np.linspace(-2, 20, 221)),
-    # UC6: Target extends beyond morph; morph coarser
+    # UC6: Target range wider than morph, finer target grid density
     (np.linspace(0, 10, 101), np.linspace(-2, 20, 421)),
-    # UC8: Target extends beyond morph; target coarser
+    # UC8: Target range wider than morph, finer morph grid density
     (np.linspace(0, 10, 401), np.linspace(-2, 20, 200)),
-    # UC10: morph starts earlier than target
+    # UC10: Morph range starts and ends earlier than target, same grid density
     (np.linspace(-2, 10, 121), np.linspace(0, 20, 201)),
-    # UC12: morph extends beyond target
+    # UC12: Morph range wider than target, same grid density
     (np.linspace(-2, 20, 221), np.linspace(0, 10, 101)),
 ]
 

--- a/tests/test_morphsqueeze.py
+++ b/tests/test_morphsqueeze.py
@@ -1,0 +1,60 @@
+import numpy as np
+import pytest
+from numpy.polynomial import Polynomial
+
+from diffpy.morph.morphs.morphsqueeze import MorphSqueeze
+
+squeeze_coeffs_list = [
+    # The order of coefficients is [a0, a1, a2, ..., an]
+    # Negative cubic squeeze coefficients
+    [-0.2, -0.01, -0.001, -0.001],
+    # Positive cubic squeeze coefficients
+    [0.2, 0.01, 0.001, 0.001],
+    # Positive and negative cubic squeeze coefficients
+    [0.2, -0.01, 0.002, -0.001],
+    # Quadratic squeeze coefficients
+    [-0.2, 0.005, -0.007],
+    # Linear squeeze coefficients
+    [0.1, 0.3],
+    # 4th order squeeze coefficients
+    [0.2, -0.01, 0.001, -0.001, 0.0004],
+    # Zeros and non-zeros, the full polynomial is applied
+    [0, 0.03, 0, -0.001],
+    # Testing zeros, expect no squeezing
+    [0, 0, 0, 0, 0, 0],
+]
+morph_target_grids = [
+    # UCs from issue 181: https://github.com/diffpy/diffpy.morph/issues/181
+    # UC2: Same grid
+    (np.linspace(0, 10, 101), np.linspace(0, 10, 101)),
+    # UC4: Target extends beyond morph
+    (np.linspace(0, 10, 101), np.linspace(-2, 20, 221)),
+    # UC6: Target extends beyond morph; morph coarser
+    (np.linspace(0, 10, 101), np.linspace(-2, 20, 421)),
+    # UC8: Target extends beyond morph; target coarser
+    (np.linspace(0, 10, 401), np.linspace(-2, 20, 200)),
+    # UC10: morph starts earlier than target
+    (np.linspace(-2, 10, 121), np.linspace(0, 20, 201)),
+    # UC12: morph extends beyond target
+    (np.linspace(-2, 20, 221), np.linspace(0, 10, 101)),
+]
+
+
+@pytest.mark.parametrize("x_morph, x_target", morph_target_grids)
+@pytest.mark.parametrize("squeeze_coeffs", squeeze_coeffs_list)
+def test_morphsqueeze(x_morph, x_target, squeeze_coeffs):
+    y_target = np.sin(x_target)
+    squeeze_polynomial = Polynomial(squeeze_coeffs)
+    x_squeezed = x_morph + squeeze_polynomial(x_morph)
+    y_morph = np.sin(x_squeezed)
+    x_morph_expected = x_morph
+    y_morph_expected = np.sin(x_morph)
+    morph = MorphSqueeze()
+    morph.squeeze = squeeze_coeffs
+    x_morph_actual, y_morph_actual, x_target_actual, y_target_actual = morph(
+        x_morph, y_morph, x_target, y_target
+    )
+    assert np.allclose(y_morph_actual, y_morph_expected)
+    assert np.allclose(x_morph_actual, x_morph_expected)
+    assert np.allclose(x_target_actual, x_target)
+    assert np.allclose(y_target_actual, y_target)

--- a/tests/test_morphsqueeze.py
+++ b/tests/test_morphsqueeze.py
@@ -7,11 +7,11 @@ from diffpy.morph.morphs.morphsqueeze import MorphSqueeze
 squeeze_coeffs_list = [
     # The order of coefficients is [a0, a1, a2, ..., an]
     # Negative cubic squeeze coefficients
-    [-0.2, -0.01, -0.001, -0.001],
+    [-0.2, -0.01, -0.001, -0.0001],
     # Positive cubic squeeze coefficients
-    [0.2, 0.01, 0.001, 0.001],
+    [0.2, 0.01, 0.001, 0.0001],
     # Positive and negative cubic squeeze coefficients
-    [0.2, -0.01, 0.002, -0.001],
+    [0.2, -0.01, 0.002, -0.0001],
     # Quadratic squeeze coefficients
     [-0.2, 0.005, -0.007],
     # Linear squeeze coefficients
@@ -19,7 +19,7 @@ squeeze_coeffs_list = [
     # 4th order squeeze coefficients
     [0.2, -0.01, 0.001, -0.001, 0.0004],
     # Zeros and non-zeros, the full polynomial is applied
-    [0, 0.03, 0, -0.001],
+    [0, 0.03, 0, -0.0001],
     # Testing zeros, expect no squeezing
     [0, 0, 0, 0, 0, 0],
 ]
@@ -51,10 +51,28 @@ def test_morphsqueeze(x_morph, x_target, squeeze_coeffs):
     y_morph_expected = np.sin(x_morph)
     morph = MorphSqueeze()
     morph.squeeze = squeeze_coeffs
-    x_morph_actual, y_morph_actual, x_target_actual, y_target_actual = morph(
-        x_morph, y_morph, x_target, y_target
-    )
-    assert np.allclose(y_morph_actual, y_morph_expected)
+    (
+        x_morph_actual,
+        y_morph_actual,
+        x_target_actual,
+        y_target_actual,
+        low_extrap_idx,
+        high_extrap_idx,
+    ) = morph(x_morph, y_morph, x_target, y_target)
+    if low_extrap_idx is None and high_extrap_idx is None:
+        assert np.allclose(y_morph_actual, y_morph_expected, atol=1e-6)
+    else:
+        interp_start = low_extrap_idx + 1 if low_extrap_idx is not None else 0
+        interp_end = (
+            high_extrap_idx
+            if high_extrap_idx is not None
+            else len(y_morph_actual)
+        )
+        assert np.allclose(
+            y_morph_actual[interp_start:interp_end],
+            y_morph_expected[interp_start:interp_end],
+            atol=1e-6,
+        )
     assert np.allclose(x_morph_actual, x_morph_expected)
     assert np.allclose(x_target_actual, x_target)
     assert np.allclose(y_target_actual, y_target)


### PR DESCRIPTION
I have written different UCs tests from issue 181 for the squeeze morph. I am keeping the morphed x-axis the same as the unmorphed as we discussed. I have left the morph function empty. My inputs are a uniform target, and a squeezed morph, then the expected morph is the unsqueezed morph.