### PR TITLE
Enable refinement of lists and dictionary input parameters

### DIFF
--- a/news/dict_lists_refinement.rst
+++ b/news/dict_lists_refinement.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Functionality for refining lists and dictionaries
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/src/diffpy/morph/morph_api.py
+++ b/src/diffpy/morph/morph_api.py
@@ -40,7 +40,7 @@ _morph_step_dict = dict(
     ],
     qdamp=morphs.MorphResolutionDamping,
     squeeze=morphs.MorphSqueeze,
-    parameters=morphs.MorphFuncy,
+    funcy=morphs.MorphFuncy,
 )
 _default_config = dict(
     scale=None,
@@ -49,7 +49,7 @@ _default_config = dict(
     baselineslope=None,
     qdamp=None,
     squeeze=None,
-    parameters=None,
+    funcy=None,
 )
 
 
@@ -144,7 +144,7 @@ def morph(
             - 'baselineslope'
             - 'qdamp'
             - 'squeeze'
-            - 'parameters'
+            - 'funcy'
 
     Returns
     -------
@@ -207,7 +207,7 @@ def morph(
         if k == "smear":
             [chain.append(el()) for el in morph_cls]
             refpars.append("baselineslope")
-        elif k == "parameters":
+        elif k == "funcy":
             morph_inst = morph_cls()
             morph_inst.function = rv_cfg.get("function", None)
             if morph_inst.function is None:

--- a/src/diffpy/morph/morph_api.py
+++ b/src/diffpy/morph/morph_api.py
@@ -143,6 +143,8 @@ def morph(
             - 'smear'
             - 'baselineslope'
             - 'qdamp'
+            - 'squeeze'
+            - 'parameters'
 
     Returns
     -------

--- a/src/diffpy/morph/morph_api.py
+++ b/src/diffpy/morph/morph_api.py
@@ -39,9 +39,17 @@ _morph_step_dict = dict(
         morph_helpers.TransformXtalRDFtoPDF,
     ],
     qdamp=morphs.MorphResolutionDamping,
+    squeeze=morphs.MorphSqueeze,
+    parameters=morphs.MorphFuncy,
 )
 _default_config = dict(
-    scale=None, stretch=None, smear=None, baselineslope=None, qdamp=None
+    scale=None,
+    stretch=None,
+    smear=None,
+    baselineslope=None,
+    qdamp=None,
+    squeeze=None,
+    parameters=None,
 )
 
 
@@ -197,6 +205,14 @@ def morph(
         if k == "smear":
             [chain.append(el()) for el in morph_cls]
             refpars.append("baselineslope")
+        elif k == "parameters":
+            morph_inst = morph_cls()
+            morph_inst.function = rv_cfg.get("function", None)
+            if morph_inst.function is None:
+                raise ValueError(
+                    "Must provide a 'function' when using 'parameters'"
+                )
+            chain.append(morph_inst)
         else:
             chain.append(morph_cls())
         refpars.append(k)

--- a/src/diffpy/morph/morphs/__init__.py
+++ b/src/diffpy/morph/morphs/__init__.py
@@ -19,6 +19,7 @@
 
 from diffpy.morph.morphs.morph import Morph  # noqa: F401
 from diffpy.morph.morphs.morphchain import MorphChain  # noqa: F401
+from diffpy.morph.morphs.morphfuncy import MorphFuncy
 from diffpy.morph.morphs.morphishape import MorphISphere, MorphISpheroid
 from diffpy.morph.morphs.morphresolution import MorphResolutionDamping
 from diffpy.morph.morphs.morphrgrid import MorphRGrid
@@ -26,6 +27,7 @@ from diffpy.morph.morphs.morphscale import MorphScale
 from diffpy.morph.morphs.morphshape import MorphSphere, MorphSpheroid
 from diffpy.morph.morphs.morphshift import MorphShift
 from diffpy.morph.morphs.morphsmear import MorphSmear
+from diffpy.morph.morphs.morphsqueeze import MorphSqueeze
 from diffpy.morph.morphs.morphstretch import MorphStretch
 
 # List of morphs
@@ -40,6 +42,8 @@ morphs = [
     MorphISpheroid,
     MorphResolutionDamping,
     MorphShift,
+    MorphSqueeze,
+    MorphFuncy,
 ]
 
 # End of file

--- a/src/diffpy/morph/morphs/morphfuncy.py
+++ b/src/diffpy/morph/morphs/morphfuncy.py
@@ -11,7 +11,7 @@ class MorphFuncy(Morph):
     yinlabel = LABEL_GR
     xoutlabel = LABEL_RA
     youtlabel = LABEL_GR
-    parnames = ["parameters"]
+    parnames = ["funcy"]
 
     def morph(self, x_morph, y_morph, x_target, y_target):
         """General morph function that applies a user-supplied function to the
@@ -50,7 +50,7 @@ class MorphFuncy(Morph):
         and target array (x_target, y_target):
         >>> morph = MorphFuncy()
         >>> morph.function = sine_function
-        >>> morph.parameters = parameters
+        >>> morph.funcy = parameters
         >>> x_morph_out, y_morph_out, x_target_out, y_target_out = morph.morph(
         ...     x_morph, y_morph, x_target, y_target)
 
@@ -59,11 +59,11 @@ class MorphFuncy(Morph):
         >>> y_morph_in = morph.y_morph_in
         >>> x_target_in = morph.x_target_in
         >>> y_target_in = morph.y_target_in
-        >>> parameters_out = morph.parameters
+        >>> parameters_out = morph.funcy
         """
         Morph.morph(self, x_morph, y_morph, x_target, y_target)
 
         self.y_morph_out = self.function(
-            self.x_morph_in, self.y_morph_in, **self.parameters
+            self.x_morph_in, self.y_morph_in, **self.funcy
         )
         return self.xyallout

--- a/src/diffpy/morph/morphs/morphfuncy.py
+++ b/src/diffpy/morph/morphs/morphfuncy.py
@@ -11,6 +11,7 @@ class MorphFuncy(Morph):
     yinlabel = LABEL_GR
     xoutlabel = LABEL_RA
     youtlabel = LABEL_GR
+    parnames = ["parameters"]
 
     def morph(self, x_morph, y_morph, x_target, y_target):
         """General morph function that applies a user-supplied function to the

--- a/src/diffpy/morph/morphs/morphsqueeze.py
+++ b/src/diffpy/morph/morphs/morphsqueeze.py
@@ -28,11 +28,11 @@ class MorphSqueeze(Morph):
 
         Configuration Variables
         -----------------------
-        squeeze : list
-            The polynomial coefficients [a0, a1, ..., an] for the squeeze
+        squeeze : Dictionary
+            The polynomial coefficients {a0, a1, ..., an} for the squeeze
             function where the polynomial would be of the form
             a0 + a1*x + a2*x^2 and so on.  The order of the polynomial is
-            determined by the length of the list.
+            determined by the length of the dictionary.
 
         Returns
         -------
@@ -46,7 +46,7 @@ class MorphSqueeze(Morph):
         Import the squeeze morph function:
         >>> from diffpy.morph.morphs.morphsqueeze import MorphSqueeze
         Provide initial guess for squeezing coefficients:
-        >>> squeeze_coeff = [0.1, -0.01, 0.005]
+        >>> squeeze_coeff = {"a0":0.1, "a1":-0.01, "a2":0.005}
         Run the squeeze morph given input morph array (x_morph, y_morph)
         and target array (x_target, y_target):
         >>> morph = MorphSqueeze()
@@ -62,7 +62,8 @@ class MorphSqueeze(Morph):
         """
         Morph.morph(self, x_morph, y_morph, x_target, y_target)
 
-        squeeze_polynomial = Polynomial(self.squeeze)
+        coeffs = [self.squeeze[f"a{i}"] for i in range(len(self.squeeze))]
+        squeeze_polynomial = Polynomial(coeffs)
         x_squeezed = self.x_morph_in + squeeze_polynomial(self.x_morph_in)
         self.y_morph_out = CubicSpline(x_squeezed, self.y_morph_in)(
             self.x_morph_in

--- a/src/diffpy/morph/refine.py
+++ b/src/diffpy/morph/refine.py
@@ -26,6 +26,8 @@ from scipy.stats import pearsonr
 class Refiner(object):
     """Class for refining a Morph or MorphChain.
 
+    This is provided to allow for custom residuals and refinement algorithms.
+
     Attributes
     ----------
     chain
@@ -158,7 +160,7 @@ class Refiner(object):
             emesg
             raise ValueError(emesg)
 
-        # Place the fit parameters back into config
+        # Place the fit parameters in config
         vals = sol
         if not hasattr(vals, "__iter__"):
             vals = [vals]

--- a/src/diffpy/morph/refine.py
+++ b/src/diffpy/morph/refine.py
@@ -55,20 +55,20 @@ class Refiner(object):
     def _update_chain(self, pvals):
         """Update the parameters in the chain."""
         updated = {}
-        for idx, val in enumerate(pvals):
-            p, subkey = self.flat_to_grouped[idx]
-            if subkey is None:
-                updated[p] = val
+        for idx, value in enumerate(pvals):
+            param, subkey = self.flat_to_grouped[idx]
+            if subkey is None:  # Scalar
+                updated[param] = value
             else:
-                if p not in updated:
-                    updated[p] = {} if isinstance(subkey, str) else []
-                if isinstance(updated[p], dict):
-                    updated[p][subkey] = val
+                if param not in updated:
+                    updated[param] = {} if isinstance(subkey, str) else []
+                if isinstance(updated[param], dict):
+                    updated[param][subkey] = value
                 else:
-                    while len(updated[p]) <= subkey:
-                        updated[p].append(0.0)
-                    updated[p][subkey] = val
-
+                    while len(updated[param]) <= subkey:
+                        updated[param].append(0.0)
+                    updated[param][subkey] = value
+        # Apply the reconstructed grouped parameter back to config
         self.chain.config.update(updated)
         return
 
@@ -149,7 +149,6 @@ class Refiner(object):
                 initial.append(val)
                 self.flat_to_grouped[len(initial) - 1] = (p, None)
 
-        # Perform least squares refinement
         sol, cov_sol, infodict, emesg, ier = leastsq(
             self.residual, initial, full_output=1
         )

--- a/src/diffpy/morph/refine.py
+++ b/src/diffpy/morph/refine.py
@@ -155,6 +155,7 @@ class Refiner(object):
         fvec = infodict["fvec"]
 
         if ier not in (1, 2, 3, 4):
+            emesg
             raise ValueError(emesg)
 
         # Place the fit parameters back into config

--- a/src/diffpy/morph/refine.py
+++ b/src/diffpy/morph/refine.py
@@ -63,13 +63,9 @@ class Refiner(object):
                 updated[param] = value
             else:
                 if param not in updated:
-                    updated[param] = {} if isinstance(subkey, str) else []
-                if isinstance(updated[param], dict):
-                    updated[param][subkey] = value
-                else:
-                    while len(updated[param]) <= subkey:
-                        updated[param].append(0.0)
-                    updated[param][subkey] = value
+                    updated[param] = {}
+                updated[param][subkey] = value
+
         # Apply the reconstructed grouped parameter back to config
         self.chain.config.update(updated)
         return
@@ -143,10 +139,6 @@ class Refiner(object):
                 for k, v in val.items():
                     initial.append(v)
                     self.flat_to_grouped[len(initial) - 1] = (p, k)
-            elif isinstance(val, list):
-                for i, v in enumerate(val):
-                    initial.append(v)
-                    self.flat_to_grouped[len(initial) - 1] = (p, i)
             else:
                 initial.append(val)
                 self.flat_to_grouped[len(initial) - 1] = (p, None)

--- a/tests/test_morph_func.py
+++ b/tests/test_morph_func.py
@@ -101,3 +101,45 @@ def test_smear_with_morph_func():
     assert np.allclose(y0, y1, atol=1e-3)  # numerical error -> 1e-4
     # verify morphed param
     assert np.allclose(smear, morphed_cfg["smear"], atol=1e-1)
+
+
+def test_squeeze_with_morph_func():
+    squeeze_init = [0, -0.001, -0.0001, 0.0001]
+    x_morph = np.linspace(0, 10, 101)
+    y_morph = 2 * np.sin(
+        x_morph + x_morph * (-0.01) - 0.0001 * x_morph**2 + 0.0002 * x_morph**3
+    )
+    expected_squeeze = [0, -0.01, -0.0001, 0.0002]
+    expected_scale = 1 / 2
+    x_target = x_morph.copy()
+    y_target = np.sin(x_target)
+    cfg = morph_default_config(scale=1.1, squeeze=squeeze_init)  # off init
+    morph_rv = morph(x_morph, y_morph, x_target, y_target, **cfg)
+    morphed_cfg = morph_rv["morphed_config"]
+    # verified they are morphable
+    x1, y1, x0, y0 = morph_rv["morph_chain"].xyallout
+    assert np.allclose(x0, x1)
+    assert np.allclose(y0, y1, atol=1e-3)  # numerical error -> 1e-4
+    # verify morphed param
+    assert np.allclose(expected_squeeze, morphed_cfg["squeeze"], atol=1e-4)
+    assert np.allclose(expected_scale, morphed_cfg["scale"], atol=1e-4)
+
+
+def test_funcy_with_morph_func():
+    def linear_function(x, y, scale, offset):
+        return (scale * x) * y + offset
+
+    x_morph = np.linspace(0, 10, 101)
+    y_morph = np.sin(x_morph)
+    x_target = x_morph.copy()
+    y_target = np.sin(x_target) * 2 * x_target + 0.4
+    cfg = morph_default_config(parameters={"scale": 1.2, "offset": 0.1})
+    cfg["function"] = linear_function
+    morph_rv = morph(x_morph, y_morph, x_target, y_target, **cfg)
+    morphed_cfg = morph_rv["morphed_config"]
+    x1, y1, x0, y0 = morph_rv["morph_chain"].xyallout
+    assert np.allclose(x0, x1)
+    assert np.allclose(y0, y1, atol=1e-6)
+    fitted_parameters = morphed_cfg["parameters"]
+    assert np.allclose(fitted_parameters["scale"], 2, atol=1e-6)
+    assert np.allclose(fitted_parameters["offset"], 0.4, atol=1e-6)

--- a/tests/test_morph_func.py
+++ b/tests/test_morph_func.py
@@ -107,22 +107,22 @@ def test_squeeze_with_morph_func():
     squeeze_init = [0, -0.001, -0.0001, 0.0001]
     x_morph = np.linspace(0, 10, 101)
     y_morph = 2 * np.sin(
-        x_morph + x_morph * (-0.01) - 0.0001 * x_morph**2 + 0.0002 * x_morph**3
+        x_morph + x_morph * 0.01 + 0.0001 * x_morph**2 + 0.001 * x_morph**3
     )
-    expected_squeeze = [0, -0.01, -0.0001, 0.0002]
+    expected_squeeze = [0, 0.01, 0.0001, 0.001]
     expected_scale = 1 / 2
-    x_target = x_morph.copy()
+    x_target = np.linspace(0, 10, 101)
     y_target = np.sin(x_target)
-    cfg = morph_default_config(scale=1.1, squeeze=squeeze_init)  # off init
+    cfg = morph_default_config(scale=1.1, squeeze=squeeze_init)
     morph_rv = morph(x_morph, y_morph, x_target, y_target, **cfg)
     morphed_cfg = morph_rv["morphed_config"]
-    # verified they are morphable
-    x1, y1, x0, y0 = morph_rv["morph_chain"].xyallout
-    assert np.allclose(x0, x1)
-    assert np.allclose(y0, y1, atol=1e-3)  # numerical error -> 1e-4
-    # verify morphed param
-    assert np.allclose(expected_squeeze, morphed_cfg["squeeze"], atol=1e-4)
-    assert np.allclose(expected_scale, morphed_cfg["scale"], atol=1e-4)
+    x_morph_out, y_morph_out, x_target_out, y_target_out = morph_rv[
+        "morph_chain"
+    ].xyallout
+    assert np.allclose(x_morph_out, x_target_out)
+    assert np.allclose(y_morph_out, y_target_out, atol=1e-6)
+    assert np.allclose(expected_squeeze, morphed_cfg["squeeze"], atol=1e-6)
+    assert np.allclose(expected_scale, morphed_cfg["scale"], atol=1e-6)
 
 
 def test_funcy_with_morph_func():
@@ -137,9 +137,11 @@ def test_funcy_with_morph_func():
     cfg["function"] = linear_function
     morph_rv = morph(x_morph, y_morph, x_target, y_target, **cfg)
     morphed_cfg = morph_rv["morphed_config"]
-    x1, y1, x0, y0 = morph_rv["morph_chain"].xyallout
-    assert np.allclose(x0, x1)
-    assert np.allclose(y0, y1, atol=1e-6)
+    x_morph_out, y_morph_out, x_target_out, y_target_out = morph_rv[
+        "morph_chain"
+    ].xyallout
+    assert np.allclose(x_morph_out, x_target_out)
+    assert np.allclose(y_morph_out, y_target_out, atol=1e-6)
     fitted_parameters = morphed_cfg["parameters"]
     assert np.allclose(fitted_parameters["scale"], 2, atol=1e-6)
     assert np.allclose(fitted_parameters["offset"], 0.4, atol=1e-6)

--- a/tests/test_morph_func.py
+++ b/tests/test_morph_func.py
@@ -133,7 +133,7 @@ def test_funcy_with_morph_func():
     y_morph = np.sin(x_morph)
     x_target = x_morph.copy()
     y_target = np.sin(x_target) * 2 * x_target + 0.4
-    cfg = morph_default_config(parameters={"scale": 1.2, "offset": 0.1})
+    cfg = morph_default_config(funcy={"scale": 1.2, "offset": 0.1})
     cfg["function"] = linear_function
     morph_rv = morph(x_morph, y_morph, x_target, y_target, **cfg)
     morphed_cfg = morph_rv["morphed_config"]
@@ -142,6 +142,6 @@ def test_funcy_with_morph_func():
     ].xyallout
     assert np.allclose(x_morph_out, x_target_out)
     assert np.allclose(y_morph_out, y_target_out, atol=1e-6)
-    fitted_parameters = morphed_cfg["parameters"]
+    fitted_parameters = morphed_cfg["funcy"]
     assert np.allclose(fitted_parameters["scale"], 2, atol=1e-6)
     assert np.allclose(fitted_parameters["offset"], 0.4, atol=1e-6)

--- a/tests/test_morph_func.py
+++ b/tests/test_morph_func.py
@@ -104,12 +104,12 @@ def test_smear_with_morph_func():
 
 
 def test_squeeze_with_morph_func():
-    squeeze_init = [0, -0.001, -0.0001, 0.0001]
+    squeeze_init = {"a0": 0, "a1": -0.001, "a2": -0.0001, "a3": 0.0001}
     x_morph = np.linspace(0, 10, 101)
     y_morph = 2 * np.sin(
         x_morph + x_morph * 0.01 + 0.0001 * x_morph**2 + 0.001 * x_morph**3
     )
-    expected_squeeze = [0, 0.01, 0.0001, 0.001]
+    expected_squeeze = {"a0": 0, "a1": 0.01, "a2": 0.0001, "a3": 0.001}
     expected_scale = 1 / 2
     x_target = np.linspace(0, 10, 101)
     y_target = np.sin(x_target)
@@ -121,7 +121,18 @@ def test_squeeze_with_morph_func():
     ].xyallout
     assert np.allclose(x_morph_out, x_target_out)
     assert np.allclose(y_morph_out, y_target_out, atol=1e-6)
-    assert np.allclose(expected_squeeze, morphed_cfg["squeeze"], atol=1e-6)
+    assert np.allclose(
+        expected_squeeze["a0"], morphed_cfg["squeeze"]["a0"], atol=1e-6
+    )
+    assert np.allclose(
+        expected_squeeze["a1"], morphed_cfg["squeeze"]["a1"], atol=1e-6
+    )
+    assert np.allclose(
+        expected_squeeze["a2"], morphed_cfg["squeeze"]["a2"], atol=1e-6
+    )
+    assert np.allclose(
+        expected_squeeze["a3"], morphed_cfg["squeeze"]["a3"], atol=1e-6
+    )
     assert np.allclose(expected_scale, morphed_cfg["scale"], atol=1e-6)
 
 

--- a/tests/test_morphfuncy.py
+++ b/tests/test_morphfuncy.py
@@ -63,7 +63,7 @@ def test_funcy(function, parameters, expected_function):
     y_morph_expected = expected_function(x_morph, y_morph)
     morph = MorphFuncy()
     morph.function = function
-    morph.parameters = parameters
+    morph.funcy = parameters
     x_morph_actual, y_morph_actual, x_target_actual, y_target_actual = (
         morph.morph(x_morph, y_morph, x_target, y_target)
     )

--- a/tests/test_morphsqueeze.py
+++ b/tests/test_morphsqueeze.py
@@ -4,24 +4,24 @@ from numpy.polynomial import Polynomial
 
 from diffpy.morph.morphs.morphsqueeze import MorphSqueeze
 
-squeeze_coeffs_list = [
-    # The order of coefficients is [a0, a1, a2, ..., an]
+squeeze_coeffs_dic = [
+    # The order of coefficients is {a0, a1, a2, ..., an}
     # Negative cubic squeeze coefficients
-    [-0.01, -0.0005, -0.0005, -1e-6],
+    {"a0": -0.01, "a1": -0.0005, "a2": -0.0005, "a3": -1e-6},
     # Positive cubic squeeze coefficients
-    [0.2, 0.01, 0.001, 0.0001],
+    {"a0": 0.2, "a1": 0.01, "a2": 0.001, "a3": 0.0001},
     # Positive and negative cubic squeeze coefficients
-    [0.2, -0.01, 0.002, -0.0001],
+    {"a0": 0.2, "a1": -0.01, "a2": 0.002, "a3": -0.0001},
     # Quadratic squeeze coefficients
-    [-0.2, 0.005, -0.0004],
+    {"a0": -0.2, "a1": 0.005, "a2": -0.0004},
     # Linear squeeze coefficients
-    [0.1, 0.3],
+    {"a0": 0.1, "a1": 0.3},
     # 4th order squeeze coefficients
-    [0.2, -0.01, 0.001, -0.001, 0.0001],
+    {"a0": 0.2, "a1": -0.01, "a2": 0.001, "a3": -0.001, "a4": 0.0001},
     # Zeros and non-zeros, the full polynomial is applied
-    [0, 0.03, 0, -0.0001],
+    {"a0": 0, "a1": 0.03, "a2": 0, "a3": -0.0001},
     # Testing zeros, expect no squeezing
-    [0, 0, 0, 0, 0, 0],
+    {"a0": 0, "a1": 0, "a2": 0, "a3": 0, "a4": 0, "a5": 0},
 ]
 morph_target_grids = [
     # UCs from issue 181: https://github.com/diffpy/diffpy.morph/issues/181
@@ -41,10 +41,11 @@ morph_target_grids = [
 
 
 @pytest.mark.parametrize("x_morph, x_target", morph_target_grids)
-@pytest.mark.parametrize("squeeze_coeffs", squeeze_coeffs_list)
+@pytest.mark.parametrize("squeeze_coeffs", squeeze_coeffs_dic)
 def test_morphsqueeze(x_morph, x_target, squeeze_coeffs):
     y_target = np.sin(x_target)
-    squeeze_polynomial = Polynomial(squeeze_coeffs)
+    coeffs = [squeeze_coeffs[f"a{i}"] for i in range(len(squeeze_coeffs))]
+    squeeze_polynomial = Polynomial(coeffs)
     x_squeezed = x_morph + squeeze_polynomial(x_morph)
     y_morph = np.sin(x_squeezed)
     low_extrap = np.where(x_morph < x_squeezed[0])[0]


### PR DESCRIPTION
I have modified the `refine.py` to allow refinement of scalars, lists, and dictionaries (before it was only scalars). I have done this by flattening lists and dictionaries accordingly and then reconstructing and regrouping the lists or dictionaries after refinement.
I have also added `MorphSqueeze` and `MorphFuncy` into `morph_api.py` and `_init_.py`. I have finally tested that we can now refine `MorphSqueeze` and `MorphFuncy` and I added these tests in `test_morph_func.py` where there are tests for other morphs as well. The tests are successful and therefore now we can refine squeeze and funcy. I am attaching some figures from the tests here. Finally, I also run all the tests for all the diffpy.morph, such as `test_refine.py`, etc., to make sure everything is working properly and they all passed. 
Refinement test for scale + squeeze morph with same x-grid:
![image](https://github.com/user-attachments/assets/53458397-7d32-4b30-881b-6cde37e925cd)
Refinement test for scale + squeeze morph with different x-grid:
![image](https://github.com/user-attachments/assets/fcadd776-3372-4918-8a7e-c1f45cda9bdc)
Refinement test for `MorphFuncy` using a linear function that is applied to a sine wave:
![image](https://github.com/user-attachments/assets/a22d60d8-e53c-4adf-96cd-3ef7f3a116db)
Note that I also compare the refined parameters to the expected ones and is working well.
 