### PR TITLE
Edge cases and error handling for the squeeze morph

### DIFF
--- a/tests/test_morphapp.py
+++ b/tests/test_morphapp.py
@@ -198,6 +198,18 @@ class TestApp:
         with pytest.raises(SystemExit):
             multiple_targets(self.parser, opts, pargs, stdout_flag=False)
 
+        # Pass a non-float list to squeeze
+        (opts, pargs) = self.parser.parse_args(
+            [
+                f"{nickel_PDF}",
+                f"{nickel_PDF}",
+                "--squeeze",
+                "1,a,0",
+            ]
+        )
+        with pytest.raises(SystemExit):
+            single_morph(self.parser, opts, pargs, stdout_flag=False)
+
     def test_morphsequence(self, setup_morphsequence):
         # Parse arguments sorting by field
         (opts, pargs) = self.parser.parse_args(

--- a/tests/test_morphio.py
+++ b/tests/test_morphio.py
@@ -163,7 +163,9 @@ class TestApp:
                 "--scale",
                 "2",
                 "--squeeze",
-                "0,-0.001,-0.0001,0.0001",
+                # Ignore duplicate commas and trailing commas
+                # Handle spaces and non-spaces
+                "0,, ,-0.001, -0.0001,0.0001,",
                 "--stretch",
                 "1",
                 "--hshift",


### PR DESCRIPTION
Throw error when invalid input is given (e.g. non-numeric list).

Indicate to use that duplicated/repeated commas and trailing commas will be removed: e.g. `0,,1,` becomes `0,1`.