### PR TITLE
Bug fix for `--smear-pdf`

### DIFF
--- a/news/smear_pdf_bug.rst
+++ b/news/smear_pdf_bug.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* When transforming from the RDF to PDF in the smear-pdf morph, we incorrectly referenced the target grid zero point, when we should be referencing the morph grid zero point. This would lead to the morph PDF being set to zero on a point corresponding to when the target PDF grid value is zero. The correct behavior is for the morph PDF to be set to zero when the morph PDF grid value is zero. This has been fixed.
+
+**Security:**
+
+* <news item>

--- a/src/diffpy/morph/morph_helpers/transformrdftopdf.py
+++ b/src/diffpy/morph/morph_helpers/transformrdftopdf.py
@@ -57,7 +57,7 @@ class TransformXtalRDFtoPDF(Morph):
             self.y_morph_out = (
                 self.y_morph_in / self.x_morph_in + morph_baseline
             )
-        self.y_morph_out[self.x_target_in == 0] = 0
+        self.y_morph_out[self.x_morph_in == 0] = 0
         return self.xyallout
 
 


### PR DESCRIPTION
See change in-line. When converting from RDF to PDF, a division by `r` is done. Since we know the point at which `r=0` corresponds to `g(r=0)=0`, we set `g(r=0)=0` to avoid a divide-by-zero. The setting for the morph `g(r)` incorrectly uses the target `r`-grid to do this setting to zero.