### PR TITLE
Move epsilon parameter in `MorphRGrid`

### DIFF
--- a/news/epsilon.rst
+++ b/news/epsilon.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* MorphRGrid can now handle grids denser than 1e-08. Previously, it was possible that multiple points on the intersection range could be excluded.
+
+**Security:**
+
+* <news item>

--- a/src/diffpy/morph/morphs/morphrgrid.py
+++ b/src/diffpy/morph/morphs/morphrgrid.py
@@ -19,9 +19,6 @@ import numpy
 
 from diffpy.morph.morphs.morph import LABEL_GR, LABEL_RA, Morph
 
-# roundoff tolerance for selecting bounds on arrays.
-epsilon = 1e-8
-
 
 class MorphRGrid(Morph):
     """Resample to specified r-grid.
@@ -71,6 +68,8 @@ class MorphRGrid(Morph):
             self.rmax = rmaxinc
         if self.rstep is None or self.rstep < rstepinc:
             self.rstep = rstepinc
+        # roundoff tolerance for selecting bounds on arrays.
+        epsilon = self.rstep / 2
         # Make sure that rmax is exclusive
         self.x_morph_out = numpy.arange(
             self.rmin, self.rmax - epsilon, self.rstep


### PR DESCRIPTION
The intent of `epsilon` is to ensure that the `rmax` point is excluded. By setting `epsilon = rstep/2`, we ensure that only that last point is excluded, even on denser grids (i.e. grids denser than `rstep=1e-08`).