### PR TITLE
Change kwargs input from dict to any

### DIFF
--- a/news/kwargs.rst
+++ b/news/kwargs.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Docstring for kwargs updated from dict to Any since various input types from kwargs are possible (e.g. a list/tuple for squeeze, a tuple for funcy, a float for smear-pdf). This should remove the warning that inputs are not dicts.
+
+**Security:**
+
+* <news item>

--- a/src/diffpy/morph/morphpy.py
+++ b/src/diffpy/morph/morphpy.py
@@ -100,7 +100,7 @@ def morph(
     plot: bool
         Show a plot of the morphed and target functions as well as the
         difference curve (default: False).
-    kwargs: Any
+    kwargs: str, float, list, tuple, bool
         See the diffpy.morph website for full list of options.
     Returns
     -------
@@ -155,7 +155,7 @@ def morph_arrays(
     plot: bool
         Show a plot of the morphed and target functions as well as the
         difference curve (default: False).
-    kwargs: Any
+    kwargs: str, float, list, tuple, bool
         See the diffpy.morph website for full list of options.
     Returns
     -------

--- a/src/diffpy/morph/morphpy.py
+++ b/src/diffpy/morph/morphpy.py
@@ -100,7 +100,7 @@ def morph(
     plot: bool
         Show a plot of the morphed and target functions as well as the
         difference curve (default: False).
-    kwargs: dict
+    kwargs: Any
         See the diffpy.morph website for full list of options.
     Returns
     -------
@@ -155,7 +155,7 @@ def morph_arrays(
     plot: bool
         Show a plot of the morphed and target functions as well as the
         difference curve (default: False).
-    kwargs: dict
+    kwargs: Any
         See the diffpy.morph website for full list of options.
     Returns
     -------


### PR DESCRIPTION
This is a docstring update. Prior to this, we get a warning if any of our kwarg entries are not dicts. The kwargs entry is supposed to denote the possible entry types, not that kwargs is a dict.