### PR TITLE
Remove subprocess calls from tests

### DIFF
--- a/news/no-subprocess.rst
+++ b/news/no-subprocess.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* Removed subprocess calls in test functions.


### PR DESCRIPTION
New tests from #249 and #250 give errors on Windows. Running as shell command (in the case of Windows) is not recommended.

We don't need to call the subprocess since we can directly simulate a CLI call similar to the tests already present in `test_morphapp.py`.