### PR TITLE
Only warn user about `squeeze` extrapolation after refinement

### DIFF
--- a/news/reduce-warns.rst
+++ b/news/reduce-warns.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Only give user extrapolation warning after refinement.
+
+**Security:**
+
+* <news item>

--- a/src/diffpy/morph/morph_io.py
+++ b/src/diffpy/morph/morph_io.py
@@ -18,12 +18,20 @@ from __future__ import print_function
 
 import inspect
 import sys
+import warnings
 from pathlib import Path
 
 import numpy
 
 import diffpy.morph.tools as tools
 from diffpy.morph import __save_morph_as__
+
+
+def custom_formatwarning(msg, *args, **kwargs):
+    return f"{msg}\n"
+
+
+warnings.formatwarning = custom_formatwarning
 
 
 def single_morph_output(
@@ -398,3 +406,34 @@ def tabulate_results(multiple_morph_results):
             }
         )
     return tabulated_results
+
+
+def handle_warnings(squeeze_morph):
+    if squeeze_morph is not None:
+        eil = squeeze_morph.extrap_index_low
+        eih = squeeze_morph.extrap_index_high
+
+        if eil is not None or eih is not None:
+            if eih is None:
+                wmsg = (
+                    "Warning: points with grid value below "
+                    f"{squeeze_morph.squeeze_cutoff_low} "
+                    f"will be extrapolated."
+                )
+            elif eil is None:
+                wmsg = (
+                    "Warning: points with grid value above "
+                    f"{squeeze_morph.squeeze_cutoff_high} "
+                    f"will be extrapolated."
+                )
+            else:
+                wmsg = (
+                    "Warning: points with grid value below "
+                    f"{squeeze_morph.squeeze_cutoff_low} and above "
+                    f"{squeeze_morph.squeeze_cutoff_high} "
+                    f"will be extrapolated."
+                )
+            warnings.warn(
+                wmsg,
+                UserWarning,
+            )

--- a/src/diffpy/morph/morphapp.py
+++ b/src/diffpy/morph/morphapp.py
@@ -546,6 +546,7 @@ def single_morph(
     # Squeeze
     squeeze_poly_deg = -1
     squeeze_dict_in = {}
+    squeeze_morph = None
     if opts.squeeze is not None:
         # Handles both list and csv input
         if (
@@ -570,7 +571,8 @@ def single_morph(
                 except ValueError:
                     parser.error(f"{coeff} could not be converted to float.")
         squeeze_poly_deg = len(squeeze_dict_in.keys())
-        chain.append(morphs.MorphSqueeze())
+        squeeze_morph = morphs.MorphSqueeze()
+        chain.append(squeeze_morph)
         config["squeeze"] = squeeze_dict_in
         # config["extrap_index_low"] = None
         # config["extrap_index_high"] = None
@@ -695,6 +697,9 @@ def single_morph(
             parser.custom_error(str(e))
     else:
         chain(x_morph, y_morph, x_target, y_target)
+
+    # THROW ANY WARNINGS HERE
+    io.handle_warnings(squeeze_morph)
 
     # Get Rw for the morph range
     rw = tools.getRw(chain)


### PR DESCRIPTION
Update to #250, which would throw a warning each step of the refinement. We only want the user to see the warning afterward since only that quantity is useful.

Targets first check point of #243