### PR TITLE
feat: add `--check-increase` option

### DIFF
--- a/news/sort-squeezed-x.rst
+++ b/news/sort-squeezed-x.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Add ``--check-increase`` option for squeeze morph.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/src/diffpy/morph/morph_io.py
+++ b/src/diffpy/morph/morph_io.py
@@ -408,7 +408,7 @@ def tabulate_results(multiple_morph_results):
     return tabulated_results
 
 
-def handle_warnings(squeeze_morph):
+def handle_extrapolation_warnings(squeeze_morph):
     if squeeze_morph is not None:
         extrapolation_info = squeeze_morph.extrapolation_info
         is_extrap_low = extrapolation_info["is_extrap_low"]
@@ -438,6 +438,28 @@ def handle_warnings(squeeze_morph):
         else:
             wmsg = None
 
+        if wmsg:
+            warnings.warn(
+                wmsg,
+                UserWarning,
+            )
+
+
+def handle_check_increase_warning(squeeze_morph):
+    if squeeze_morph is not None:
+        if squeeze_morph.squeeze_info["monotonic"]:
+            wmsg = None
+        else:
+            overlapping_regions = squeeze_morph.squeeze_info[
+                "overlapping_regions"
+            ]
+            wmsg = (
+                "Warning: The squeeze morph has interpolated your morphed "
+                "function from a non-monotonically increasing grid. "
+                "This can result in strange behavior in the regions "
+                f"{overlapping_regions}. To disable this setting, "
+                "please enable --check-increasing."
+            )
         if wmsg:
             warnings.warn(
                 wmsg,

--- a/src/diffpy/morph/morphapp.py
+++ b/src/diffpy/morph/morphapp.py
@@ -208,6 +208,16 @@ def create_option_parser():
         ),
     )
     group.add_option(
+        "--check-increase",
+        action="store_true",
+        dest="check_increase",
+        help=(
+            "Disable squeeze morph to interpolat morphed function "
+            "from a non-monotonically increasing grid."
+        ),
+    )
+
+    group.add_option(
         "--smear",
         type="float",
         metavar="SMEAR",
@@ -571,7 +581,7 @@ def single_morph(
                 except ValueError:
                     parser.error(f"{coeff} could not be converted to float.")
         squeeze_poly_deg = len(squeeze_dict_in.keys())
-        squeeze_morph = morphs.MorphSqueeze()
+        squeeze_morph = morphs.MorphSqueeze(check_increase=opts.check_increase)
         chain.append(squeeze_morph)
         config["squeeze"] = squeeze_dict_in
         # config["extrap_index_low"] = None
@@ -701,8 +711,9 @@ def single_morph(
         chain(x_morph, y_morph, x_target, y_target)
 
     # THROW ANY WARNINGS HERE
-    io.handle_warnings(squeeze_morph)
-    io.handle_warnings(shift_morph)
+    io.handle_extrapolation_warnings(squeeze_morph)
+    io.handle_check_increase_warning(squeeze_morph)
+    io.handle_extrapolation_warnings(shift_morph)
 
     # Get Rw for the morph range
     rw = tools.getRw(chain)

--- a/src/diffpy/morph/morphpy.py
+++ b/src/diffpy/morph/morphpy.py
@@ -51,6 +51,7 @@ def __get_morph_opts__(parser, scale, stretch, smear, plot, **kwargs):
         "reverse",
         "diff",
         "get-diff",
+        "check-increase",
     ]
     opts_to_ignore = ["multiple-morphs", "multiple-targets"]
     for opt in opts_storing_values:


### PR DESCRIPTION
### What problem does this PR address?

<!-- Provide a brief overview and link to the issue. Attach outputs, including screenshots (before/after), if helpful for the reviewer. -->

Implement some of the functionalities mentioned in #256

`--check-increase` option is added for `squeeze morph`. When it is applied, the non-strictly-increasing x will raise an error; otherwise, it will only throw warnings.

### What should the reviewer(s) do?

<!-- Merge the code, provide feedback, initiate a discussion, etc. -->

<!--
Use the following checklist items when applicable (select only what applies):
- [ ] This PR introduces a public-facing change (e.g., figures, CLI input/output, API).
    - [ ] Documentation (e.g., tutorials, examples, README) has been updated.
    - [ ] A tracking issue or plan to update documentation exists.
- [ ] This PR affects internal functionality only (no user-facing change).
-->

Please check the implementations.